### PR TITLE
FF: Add missing RadialStim library import & bump up version.

### DIFF
--- a/psychopy_visionscience/__init__.py
+++ b/psychopy_visionscience/__init__.py
@@ -9,7 +9,7 @@
 scientists.
 """
 
-__version__ = '0.0.1'
+__version__ = '0.0.2'
 
 # NOTE: Be sure to register entry points in the `pyproject.toml` file.
 
@@ -18,6 +18,7 @@ __version__ = '0.0.1'
 #
 from .noise import NoiseStim
 from .secondorder import EnvelopeGrating
+from .radial import RadialStim
 
 # ------------------------------------------------------------------------------
 # Components

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "psychopy-visionscience"
-version = "0.0.1"
+version = "0.0.2"
 description = "Stimuli useful for vision scientists."
 readme = "README.md"
 requires-python = ">= 3.7"


### PR DESCRIPTION
* Added missing library import for the moved RadialStim.
* Bumped up plugin version for the addition of new component.

#### Also opened another PR for [RF: Moved radial to plugin](https://github.com/psychopy/psychopy/pull/5942) in the main repo. @TEParsons  @mdcutone 